### PR TITLE
various changes to iosc test, see full log

### DIFF
--- a/scripts/rtos_iosc_testing.c
+++ b/scripts/rtos_iosc_testing.c
@@ -12,6 +12,7 @@
 // TODO: figure out message passing interface and get other more interesting data
 // lcn2kai env doesnt have gcc , obviously, so this has to be cross compiled and then copied over
 // to compile it , you'll need an extracted root fs (or at least the needed binaries) and arm eabi
+// on debian install package gcc-arm-linux-gnueabi
 
 // compile like so:
 // arm-linux-gnueabi-gcc   --sysroot=[PATH_TO_ROOTFS_COPY] -B [PATH_TO_ROOTFS_COPY] rtos_iosc_testing.c -o rtos_iosc_testing -ldl
@@ -19,21 +20,28 @@
 // ./rtos_iosc_testing 0xdfe 0x18 /dev/kds 
 // tends to lead to a crash which can also bring down the whole OS, probably not cleaning up something
 
-void hexdump(char *p, int size) {
-	for (int i = 0; i < size; i++) {
+void dump(char *p, int size) {
+	for (int i = 0; i < size; i+=16) {
 		if(i && !(i % 16)) printf("\n");
-		printf("%02x", p[i]);
-	}
-	printf("\n");
-}
-
-void printstrings(char *p, int size) {
-	for (int i = 0; i < size; i++) {
-		if(i && !(i % 16)) printf("\n");
-		if (p[i] >= 0x21 && p[i] <= 0x7e) {
-			printf("%c", p[i]);
-		} else {
-			printf(".");
+		for (int j = 0; j < 16; j++) {
+			if (j == 8) printf(" ");
+			if (i + j >= size) {
+				for (int k = j; k < 16; k++) {
+					if (k == 8) printf(" ");
+					printf("  ");
+				}
+				break;
+			}
+			printf("%02x", p[i+j]);
+		}
+		printf("  ");
+		for (int j = 0; j < 16; j++) {
+			if (i+j >= size) break;
+			if (p[i+j] >= 0x21 && p[i+j] <= 0x7e) {
+				printf("%c", p[i+j]);
+			} else {
+				printf(".");
+			}
 		}
 	}
 	printf("\n");
@@ -51,6 +59,12 @@ int main(int argc, char **argv){
 			char data[1012];
 		} ioread;
 	} buffer;
+
+	if (argc < 4) {
+		printf("usage: %s <code> <len> <dev> [loop]\n", argv[0]);
+		return EXIT_FAILURE;
+	}
+
 	int (*OSAL_IOOpen)(const char*,int param);
 	void (*OSAL_s32IOClose)(int fp);
 	void (*OSAL_s32IORead)(int fp,char *buff,int code);
@@ -73,7 +87,7 @@ int main(int argc, char **argv){
 	if (fp == 0xffffffff) {
 	    printf("No such device: %s\n",argv[3]);
 		dlclose(handle);
-		exit(0);
+		return EXIT_FAILURE;
 	}
 	//bReadEntry(this,0xdfe,0x18,(uchar *)(this + 5));
 	unsigned short word1 = (unsigned short)strtol(argv[1],0,16);
@@ -87,9 +101,11 @@ int main(int argc, char **argv){
 		if (buffer.ioread.code == 0xffff) continue;
 
 		printf("\n%04x %04x %04x:\n", buffer.ioread.code, buffer.ioread.len, buffer.ioread.unknown);
-		hexdump(buffer.ioread.data, buffer.ioread.len);
-		printstrings(buffer.ioread.data, buffer.ioread.len);
+		dump(buffer.ioread.data, buffer.ioread.len);
+
+		if (argc < 5) break;
 	}
 	OSAL_s32IOClose(fp);
 	dlclose(handle);
+	return EXIT_SUCCESS;
 }

--- a/scripts/rtos_iosc_testing.c
+++ b/scripts/rtos_iosc_testing.c
@@ -24,7 +24,6 @@ void dump(char *p, int size) {
 	for (int i = 0; i < size; i+=16) {
 		if(i && !(i % 16)) printf("\n");
 		for (int j = 0; j < 16; j++) {
-			if (j == 8) printf(" ");
 			if (i + j >= size) {
 				for (int k = j; k < 16; k++) {
 					if (k == 8) printf(" ");
@@ -32,6 +31,7 @@ void dump(char *p, int size) {
 				}
 				break;
 			}
+			if (j == 8) printf(" ");
 			printf("%02x", p[i+j]);
 		}
 		printf("  ");
@@ -89,7 +89,7 @@ int main(int argc, char **argv){
 		dlclose(handle);
 		return EXIT_FAILURE;
 	}
-	//bReadEntry(this,0xdfe,0x18,(uchar *)(this + 5));
+
 	unsigned short word1 = (unsigned short)strtol(argv[1],0,16);
 	unsigned short word2 = (unsigned short)strtol(argv[2],0,16);
 	for (; word1 < 0xffff; word1++){


### PR DESCRIPTION
prevent overflow of word1+i in for loop
memset entire buffer, not just first 2000 bytes (probably overkill)
call OSAL_s32IORead with readbuff not &readbuff
add a few more dlclose's in exit cases
simply the code a bit and reformat (sorry, makes diff hard)